### PR TITLE
Add Magic Switch to Peripheral Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Pull request!
 - [💰⭐️ AirBuddy](https://v2.airbuddy.app/?ref=bradleychambers2) | iOS-like airpods device animation, connect with commands
 - [💰 Better Mouse](https://better-mouse.com) | Aims to replace 3rd party mouse drivers
 - [💰 SteerMouse](http://www.plentycom.jp/en/steermouse/index.html) | Control mouse settings on a hardware level
+- [💰 Magic Switch](https://magic-switch.com) | Allows you to switch your Magic Mouse, Magic Keyboard & Magic Trackpad between multiple Macs with different Apple IDs
 
 ### 👨‍💻 Productivity Apps
 - [⭐️ Alfred](https://www.alfredapp.com) | Replaces spotlight, instant app/files/folder/web search, see [Alfred Powerpack](#Alfred-Powerpack)


### PR DESCRIPTION
Proposes to include **Magic Switch**. A neat little peripheral utility app that lets you switch your Magic Keyboard, mouse and trackpad between multiple Mac devices. It does not require both devices to have the same Apple ID. It also features cool features like: Keyboard Shortcuts & Copying text from one Mac to the other.