### PR TITLE
Add SnapHotkey to Windows Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Pull request!
 - [💰⭐️ Magnet](https://apps.apple.com/ca/app/magnet/id441258766?mt=12) | Essentially a paid version of Tiles
 - [💰 Swish](https://highlyopinionated.co/swish/) | Trackpad based windows tiling along with commands
 - [💰 Wins](https://wins.cool) | A Brand New Window Manager for macOS. Bring System-level Arrange Window features to Mac. Dock Window Previewer.Shake to hide other windows. Floating Split Window and more
+- [💰 SnapHotkey](https://snaphotkey.com) | Assign keyboard shortcuts directly to apps — press once to focus, press again to hide. Distinguishes Left/Right modifier keys for double the shortcut slots
 
 
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ Pull request!
 - [Tiles](https://freemacsoft.net/tiles/) | Drag windows to the side or use commands to tile them 
 - [Yabai](https://github.com/koekeishiya/yabai) | A tiling window manager for macOS based on binary space partitioning
 - [💰⭐️ Magnet](https://apps.apple.com/ca/app/magnet/id441258766?mt=12) | Essentially a paid version of Tiles
+- [💰 SnapHotkey](https://snaphotkey.com) | Assign keyboard shortcuts directly to apps — press once to focus, press again to hide. Distinguishes Left/Right modifier keys for double the shortcut slots
 - [💰 Swish](https://highlyopinionated.co/swish/) | Trackpad based windows tiling along with commands
 - [💰 Wins](https://wins.cool) | A Brand New Window Manager for macOS. Bring System-level Arrange Window features to Mac. Dock Window Previewer.Shake to hide other windows. Floating Split Window and more
-- [💰 SnapHotkey](https://snaphotkey.com) | Assign keyboard shortcuts directly to apps — press once to focus, press again to hide. Distinguishes Left/Right modifier keys for double the shortcut slots
 
 
 


### PR DESCRIPTION
[SnapHotkey](https://snaphotkey.com) is a macOS app that lets you assign keyboard shortcuts directly to specific apps — press once to focus the app, press the same shortcut again to hide it.

Key features:
- Direct hotkey-to-app mapping (no cycling, no search)
- Toggle show/hide with the same shortcut
- Distinguishes Left/Right modifier keys (doubles available shortcut slots)
- Same-app multi-window cycling on repeated presses

It fits alongside AltTab in the Windows Management section as a complementary tool — AltTab improves Cmd+Tab cycling, SnapHotkey replaces cycling entirely with direct access shortcuts.

Price: $9.99 one-time (paid, hence the 💰 icon)