### PR TITLE
Add Pesty (native open-source clipboard manager) to Productivity Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Pull request!
 - [AutoFocus](https://github.com/synappser/AutoFocus) | Automatically raise windows to prominence through your mouse
 - [Figr](https://www.figr.app) | Unit conversion tool
 - [Maccy](https://maccy.app) | Clipboard manager
+- [Pesty](https://github.com/momenbasel/pesty) | Native open-source clipboard manager, color-coded clipboard strip with pinboards, instant search and keyboard pasting
 - [Raycast](https://www.raycast.com) | Replaces spotlight with a great extension store
 - [💰 Forklift](https://binarynights.com) |  File Manager and FTP/SFTP/WebDAV/Amazon S3 client
 - [💰 Hazeover](https://hazeover.com) | Dim the entire windows except for the app in focus


### PR DESCRIPTION
## Adding Pesty to Productivity Apps

[Pesty](https://github.com/momenbasel/pesty) is a free, open-source, native SwiftUI clipboard manager for macOS - a slide-up, color-coded clipboard strip with pinboards, instant search, and keyboard-driven pasting.

It fits right next to Maccy in the Productivity Apps section as another native clipboard manager, and brings a different UX (the slide-up strip / pinboard model) for people who want that style.

### Why it's a good fit for this list
- **Apple Silicon native** - universal binary, SwiftUI, zero third-party dependencies.
- **Open source + free** - install via Homebrew: `brew install --cask momenbasel/pesty/pesty`. MIT licensed.
- **Properly distributed** - Developer ID signed and Apple-notarized (runs cleanly, no Gatekeeper hassle). Also on the Mac App Store for those who prefer it.
- **On-topic** - clipboard managers are already represented (Maccy); this adds a native alternative.

### Entry (added after Maccy, before Raycast - alphabetical order preserved)
```
- [Pesty](https://github.com/momenbasel/pesty) | Native open-source clipboard manager, color-coded clipboard strip with pinboards, instant search and keyboard pasting
```

Links:
- Repo: https://github.com/momenbasel/pesty
- Landing page: https://www.moamenbasel.com/pesty/

No 💰 icon since a fully functional free open-source build is available via Homebrew, consistent with the list's legend.